### PR TITLE
Dependency j2cl-uber unnecessary removed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,12 +149,6 @@
 
         <dependency>
             <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-uber</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
             <artifactId>j2cl-uber-test</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>


### PR DESCRIPTION
- transitive via j2cl-uber-test